### PR TITLE
Bump panther-cli to 0.0.29

### DIFF
--- a/Formula/panther-cloud-connected-setup.rb
+++ b/Formula/panther-cloud-connected-setup.rb
@@ -1,5 +1,5 @@
 class PantherCloudConnectedSetup < Formula
-  # Platform-specific checksums for easy programmatic updates
+  # Used for programmatic updates (see update-formula.sh)
   CHECKSUMS = {
     darwin_x86_64: "632e08e3fd6f6815ccca31df8aff80c4b43f0bba3220609ffd8a564342a47dfb",
     darwin_arm64: "6d0085f2de66ec67f0d2e531901441e4b7d361a721c9680f6aac887bac552ede",

--- a/Formula/panther-cloud-connected-setup.rb
+++ b/Formula/panther-cloud-connected-setup.rb
@@ -1,9 +1,17 @@
 class PantherCloudConnectedSetup < Formula
+  # Platform-specific checksums for easy programmatic updates
+  CHECKSUMS = {
+    darwin_x86_64: "632e08e3fd6f6815ccca31df8aff80c4b43f0bba3220609ffd8a564342a47dfb",
+    darwin_arm64: "6d0085f2de66ec67f0d2e531901441e4b7d361a721c9680f6aac887bac552ede",
+    linux_x86_64: "ffa70b5ef1eac7350d818e275581cf7ca31e5e46e7ec72ee2f43168270a25d2a",
+    linux_arm64: "aa0714c0ad86192501ada7774a454572a2ca71666f09c273284c4dc76fe803e6"
+  }.freeze
+
   desc "Tools for Panther deployments"
   homepage "https://github.com/panther-labs/panther-cli"
   # Specify the version of the release. This will be used in the binary URLs.
   # You will update this and the sha256 checksums for each new release.
-  version "0.0.28"
+  version "0.0.29"
   license "Apache-2.0"
 
   # For HEAD installs, we build from source.
@@ -24,22 +32,22 @@ class PantherCloudConnectedSetup < Formula
   on_macos do
     on_intel do # x86_64
       url "https://github.com/panther-labs/panther-cli/releases/download/v#{version}/panther-cli_Darwin_x86_64.tar.gz"
-      sha256 "9ec32f7ad7632675229ffbf42999879bd7ed5d10d8520527c2d7f38cb4902501"
+      sha256 CHECKSUMS[:darwin_x86_64]
     end
     on_arm do # arm64
       url "https://github.com/panther-labs/panther-cli/releases/download/v#{version}/panther-cli_Darwin_arm64.tar.gz"
-      sha256 "e6960c9cb038f8d26d3c67f484237eecbda6b9fabcbeca8bfc016594bc5cfd9c"
+      sha256 CHECKSUMS[:darwin_arm64]
     end
   end
 
   on_linux do
     on_intel do # x86_64
       url "https://github.com/panther-labs/panther-cli/releases/download/v#{version}/panther-cli_Linux_x86_64.tar.gz"
-      sha256 "056899b1077f4e9c90b17f673c0e8cc62f0840d719fd3bfe30bcbd95944a7770"
+      sha256 CHECKSUMS[:linux_x86_64]
     end
     on_arm do # arm64
       url "https://github.com/panther-labs/panther-cli/releases/download/v#{version}/panther-cli_Linux_arm64.tar.gz"
-      sha256 "b5530b361aa2123b9dac9f62579760c420358476dcfdd5b33e3441d80293d432"
+      sha256 CHECKSUMS[:linux_arm64]
     end
   end
 

--- a/justfile
+++ b/justfile
@@ -1,0 +1,3 @@
+# Update the Homebrew formula with checksums from a GitHub release
+update-formula VERSION:
+    ./util/update-formula.sh {{VERSION}}

--- a/util/update-formula.sh
+++ b/util/update-formula.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+VERSION="${1:-}"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+FORMULA_FILE="${REPO_ROOT}/Formula/panther-cloud-connected-setup.rb"
+
+if [[ -z "$VERSION" ]]; then
+    echo "Usage: $0 <version>"
+    echo "Example: $0 0.0.29"
+    exit 1
+fi
+
+CHECKSUMS_URL="https://github.com/panther-labs/panther-cli/releases/download/v${VERSION}/panther-cli_${VERSION}_checksums.txt"
+
+echo "Fetching checksums for version ${VERSION}..."
+
+if ! CHECKSUMS=$(curl -fsSL "${CHECKSUMS_URL}"); then
+    echo "Error: Failed to fetch checksums from ${CHECKSUMS_URL}"
+    echo "Please verify the version exists as a GitHub release"
+    exit 1
+fi
+
+echo "Parsing checksums..."
+DARWIN_X86_64=$(echo "$CHECKSUMS" | grep "panther-cli_Darwin_x86_64.tar.gz" | awk '{print $1}')
+DARWIN_ARM64=$(echo "$CHECKSUMS" | grep "panther-cli_Darwin_arm64.tar.gz" | awk '{print $1}')
+LINUX_X86_64=$(echo "$CHECKSUMS" | grep "panther-cli_Linux_x86_64.tar.gz" | awk '{print $1}')
+LINUX_ARM64=$(echo "$CHECKSUMS" | grep "panther-cli_Linux_arm64.tar.gz" | awk '{print $1}')
+
+if [[ -z "$DARWIN_X86_64" || -z "$DARWIN_ARM64" || -z "$LINUX_X86_64" || -z "$LINUX_ARM64" ]]; then
+    echo "Error: Failed to parse one or more checksums"
+    exit 1
+fi
+
+echo "Checksums found: ($CHECKSUMS_URL)"
+echo "  Darwin x86_64: $DARWIN_X86_64"
+echo "  Darwin arm64:  $DARWIN_ARM64"
+echo "  Linux x86_64:  $LINUX_X86_64"
+echo "  Linux arm64:   $LINUX_ARM64"
+
+echo ""
+echo "Updating ${FORMULA_FILE}..."
+
+sed -i '' \
+    -e "s/darwin_x86_64: \"[^\"]*\"/darwin_x86_64: \"${DARWIN_X86_64}\"/" \
+    -e "s/darwin_arm64: \"[^\"]*\"/darwin_arm64: \"${DARWIN_ARM64}\"/" \
+    -e "s/linux_x86_64: \"[^\"]*\"/linux_x86_64: \"${LINUX_X86_64}\"/" \
+    -e "s/linux_arm64: \"[^\"]*\"/linux_arm64: \"${LINUX_ARM64}\"/" \
+    -e "s/version \"[^\"]*\"/version \"${VERSION}\"/" \
+    "${FORMULA_FILE}"
+
+echo "✓ Formula updated successfully!"


### PR DESCRIPTION
Updates panther-cli to 0.0.29 and adds a new shell script/just recipe to make these updates easier in the future.